### PR TITLE
Allow mixing of args uid and gid

### DIFF
--- a/lib/ProcessContainerFork.js
+++ b/lib/ProcessContainerFork.js
@@ -54,8 +54,11 @@ if (process.env.uid || process.env.gid) {
   try {
     if (process.env.gid)
       process.setgid(process.env.gid);
-    if (process.env.uid)
+    if (process.env.uid){
+      process.initgid(process.env.uid, process.env.uid);
+      process.setgid(process.env.uid);
       process.setuid(process.env.uid);
+    }
   } catch(e) {
     setTimeout(function() {
       console.error('%s on call %s', e.message, e.syscall);

--- a/lib/ProcessContainerFork.js
+++ b/lib/ProcessContainerFork.js
@@ -52,10 +52,10 @@ if (process.connected &&
 // uid/gid management
 if (process.env.uid || process.env.gid) {
   try {
-    if (process.env.uid)
-      process.setuid(process.env.uid);
     if (process.env.gid)
       process.setgid(process.env.gid);
+    if (process.env.uid)
+      process.setuid(process.env.uid);
   } catch(e) {
     setTimeout(function() {
       console.error('%s on call %s', e.message, e.syscall);


### PR DESCRIPTION
Reversed the order of setting uid and gid. When uid is set first, the process doesn't have permission to set the gid. So they've been swapped.

Please always submit pull requests on the development branch.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2957
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
